### PR TITLE
Add HUD controls and accessibility improvements

### DIFF
--- a/assets/hexmeld-icon.svg
+++ b/assets/hexmeld-icon.svg
@@ -1,0 +1,18 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <defs>
+    <linearGradient id="hexmeldGradient" x1="12" y1="6" x2="52" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6c7bff"/>
+      <stop offset="1" stop-color="#28307a"/>
+    </linearGradient>
+  </defs>
+  <path d="M32 3 58 17v30L32 61 6 47V17z" fill="url(#hexmeldGradient)" stroke="#0b1020" stroke-width="2"/>
+  <g fill="none" stroke="#e8ebf0" stroke-width="2" stroke-linecap="round">
+    <path d="M32 15 44 22v12L32 41 20 34V22z"/>
+    <path d="M32 15v26" stroke-linejoin="round"/>
+    <path d="M20 22 8 29"/>
+    <path d="M44 22 56 29"/>
+    <path d="M20 34 8 41"/>
+    <path d="M44 34 56 41"/>
+  </g>
+  <circle cx="32" cy="28" r="4" fill="#e8ebf0"/>
+</svg>

--- a/assets/manifest.webmanifest
+++ b/assets/manifest.webmanifest
@@ -1,0 +1,1 @@
+{"name":"Hexmeld","short_name":"Hexmeld","icons":[{"src":"assets/hexmeld-icon.svg","sizes":"any","type":"image/svg+xml"}],"start_url":"../index.html","display":"standalone","theme_color":"#0b1020","background_color":"#0b1020"}

--- a/index.html
+++ b/index.html
@@ -4,263 +4,137 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Hexmeld - Hexagonal Puzzle Game</title>
+    <link rel="icon" href="assets/hexmeld-icon.svg" type="image/svg+xml">
+    <link rel="mask-icon" href="assets/hexmeld-icon.svg" color="#5b7fff">
+    <meta name="theme-color" content="#0b1020">
+    <link rel="manifest" href="assets/manifest.webmanifest">
     <style>
-        * {
-            box-sizing: border-box;
-        }
-
-        body {
-            margin: 0;
-            padding: 0;
-            font-family: Arial, sans-serif;
-            background-color: #f0f0f0;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            min-height: 100vh;
-        }
-
-        header {
-            width: 100%;
-            background-color: #333;
-            color: white;
-            padding: 20px 0;
-            text-align: center;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-        }
-
-        header h1 {
-            margin: 0;
-            font-size: 32px;
-            font-weight: bold;
-        }
-
-        main {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            padding: 10px;
-            width: 100%;
-        }
-
-        footer {
-            width: 100%;
-            background-color: #333;
-            color: white;
-            padding: 25px 0;
-            text-align: center;
-            font-size: 14px;
-        }
-
-        footer a {
-            color: #4CAF50;
-            text-decoration: none;
-            margin: 0 10px;
-        }
-
-        footer a:hover {
-            text-decoration: underline;
-        }
-
-        .version {
-            font-size: 11px;
-            color: #999;
-            margin-top: 5px;
-        }
-
-        #gameContainer {
-            background-color: white;
-            padding: 15px;
-            border-radius: 10px;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-            max-width: 100%;
-            width: 100%;
-        }
-
-        #scoreBoard {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-            margin-bottom: 15px;
-            font-size: 16px;
-            flex-wrap: wrap;
-            gap: 10px;
-        }
-
-        .leftStats, .rightStats {
-            display: flex;
-            flex-direction: column;
-            gap: 5px;
-        }
-
-        .rightStats {
-            align-items: flex-end;
-        }
-
-        #score, #turns, #highScoreDisplay {
-            font-weight: bold;
-            font-size: 20px;
-            color: #333;
-        }
-
-        .stat {
-            font-size: 16px;
-        }
-
-        #preview {
-            display: flex;
-            gap: 8px;
-            align-items: center;
-        }
-
-        .previewBall {
-            width: 25px;
-            height: 25px;
-            border-radius: 50%;
-            border: 2px solid #333;
-        }
-
-        #canvas {
-            border: 2px solid #333;
-            display: block;
-            cursor: pointer;
-            max-width: 100%;
-            height: auto;
-            margin: 0 auto;
-        }
-
-        @media (max-width: 768px) {
-            #canvas {
-                width: 100%;
-            }
-
-            #gameContainer {
-                padding-left: 0;
-                padding-right: 0;
-            }
-        }
-
-        #gameOver {
-            position: fixed;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            background-color: rgba(0, 0, 0, 0.8);
-            color: white;
-            padding: 30px 20px;
-            border-radius: 10px;
-            font-size: 28px;
-            font-weight: bold;
-            display: none;
-            text-align: center;
-            max-width: 90%;
-        }
-
-        #gameOver p {
-            margin: 10px 0;
-            font-size: 16px;
-        }
-
-        #resetButton {
-            margin-top: 20px;
-            padding: 10px 30px;
-            font-size: 18px;
-            font-weight: bold;
-            background-color: #4CAF50;
-            color: white;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
-        }
-
-        #resetButton:hover {
-            background-color: #45a049;
-        }
-
-        @media (max-width: 600px) {
-            header h1 {
-                font-size: 24px;
-            }
-
-            header {
-                padding: 15px 0;
-            }
-
-            main {
-                padding: 5px;
-            }
-
-            #gameContainer {
-                padding: 10px 0;
-            }
-
-            #scoreBoard {
-                font-size: 14px;
-            }
-
-            #score {
-                font-size: 18px;
-            }
-
-            .previewBall {
-                width: 20px;
-                height: 20px;
-            }
-
-            #gameOver {
-                font-size: 24px;
-                padding: 20px 15px;
-            }
-
-            #gameOver p {
-                font-size: 14px;
-            }
-
-            footer {
-                font-size: 12px;
-                padding: 10px 0;
-            }
-        }
+        :root{--bg:#0b1020;--panel:#11182a;--text:#e8ebf0;--muted:#93a0b4;--primary:#5b7fff;--danger:#ff6b6b;--gap:12px}
+        html{color-scheme:dark light}
+        @media (prefers-color-scheme: light){:root{--bg:#f6f7fb;--panel:#fff;--text:#0f1422;--muted:#5b667a}}
+        *,*::before,*::after{box-sizing:border-box}
+        body{margin:0;min-height:100vh;display:flex;flex-direction:column;gap:var(--gap);padding:var(--gap);background:var(--bg);color:var(--text);font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Arial}
+        body.theme-dark{color-scheme:dark}
+        body.theme-light{color-scheme:light}
+        .panel{max-width:920px;width:100%;margin:0 auto;padding:12px;background:var(--panel);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.2)}
+        .header{display:flex;justify-content:space-between;align-items:baseline;gap:var(--gap)}
+        h1{font-size:1.4rem;margin:0}
+        .meta{color:var(--muted)}
+        .button{display:inline-block;padding:.5rem .75rem;border-radius:8px;border:0;font-weight:600;color:#fff;background:var(--primary);cursor:pointer;transition:transform .12s ease,filter .12s ease}
+        .button:hover{transform:translateY(-1px);filter:brightness(1.08)}
+        .button:active{transform:translateY(0);filter:brightness(.95)}
+        .button.ghost{background:transparent;outline:1px solid #0004;color:var(--text)}
+        .button.danger{background:var(--danger)}
+        .button:disabled{opacity:.5;cursor:not-allowed}
+        .flash-red{animation:flash .28s ease-in-out 0s 2}
+        @keyframes flash{50%{filter:brightness(1.8) saturate(1.4)}}
+        main{flex:1;display:flex;flex-direction:column;align-items:center;gap:var(--gap);width:100%}
+        #gameContainer{display:flex;flex-direction:column;gap:var(--gap);align-items:center}
+        #canvas{width:100%;height:auto;max-width:820px;border-radius:12px;background:#0001;border:1px solid #0004;box-shadow:0 12px 24px rgba(0,0,0,.25)}
+        #preview{display:flex;gap:8px;align-items:center;font-weight:600}
+        .previewBall{width:22px;height:22px;border-radius:50%;border:2px solid rgba(0,0,0,.35)}
+        footer{margin-top:auto;text-align:center;font-size:.85rem;color:var(--muted)}
+        footer a{color:inherit;text-decoration:none}
+        footer a:hover{text-decoration:underline}
+        #versionDisplay{margin-top:6px;font-size:.75rem}
+        #gameOver{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;background:rgba(11,16,32,.85);backdrop-filter:blur(4px);z-index:20}
+        #gameOver .panel{max-width:360px;text-align:center}
+        #gameOver h2{margin:0 0 12px;font-size:1.5rem}
+        #gameOver p{margin:6px 0;color:var(--muted)}
+        #resetButton{margin-top:16px}
+        .cb-hint{font-size:.9em;color:var(--muted)}
+        @media (max-width:768px){body{padding:var(--gap) var(--gap) calc(var(--gap)*2)};#canvas{max-width:100%;border-radius:8px}}
     </style>
 </head>
 <body>
-    <header>
-        <h1>Hexmeld</h1>
+    <header class="panel header" role="banner">
+      <div>
+        <h1 style="display:flex;gap:8px;align-items:center;margin:0">
+          <img src="assets/hexmeld-icon.svg" alt="" width="24" height="24"> Hexmeld
+        </h1>
+        <div class="meta">Score <strong id="score">0</strong> · High <strong id="high">0</strong> · Turn <strong id="turn">0</strong></div>
+      </div>
+      <div style="display:flex;gap:8px;align-items:center">
+        <button id="themeToggle" class="button ghost" aria-pressed="false" title="Toggle theme">Theme</button>
+        <button id="cbToggle" class="button ghost" aria-pressed="false" title="Color-blind mode">CB</button>
+        <button id="playAgain" class="button" title="Restart">Play Again</button>
+      </div>
     </header>
 
     <main>
-    <div id="gameContainer">
-        <div id="scoreBoard">
-            <div class="leftStats">
-                <div class="stat">Score: <span id="score">0</span></div>
-                <div class="stat">High: <span id="highScoreDisplay">0</span></div>
-            </div>
-            <div class="rightStats">
-                <div id="preview">
-                    <span>Next:</span>
-                </div>
-                <div class="stat">Turn: <span id="turns">0</span></div>
-            </div>
+      <section class="panel" id="gameContainer">
+        <div id="preview" class="meta" aria-live="polite">
+          <span>Next:</span>
         </div>
         <canvas id="canvas"></canvas>
-    </div>
-    <div id="gameOver">
-        GAME OVER
-        <p>Your Score: <span id="finalScore">0</span> (Turn <span id="finalTurns">0</span>)</p>
-        <p>High Score: <span id="highScore">0</span></p>
-        <button id="resetButton">Play Again</button>
-    </div>
+        <div class="cb-hint" id="cbHint" hidden>Color-blind overlay active.</div>
+      </section>
     </main>
 
+    <div id="gameOver">
+      <div class="panel">
+        <h2>Game Over</h2>
+        <p>Your Score: <span id="finalScore">0</span> · Turn <span id="finalTurns">0</span></p>
+        <p>High Score: <span id="highScore">0</span></p>
+        <button id="resetButton" class="button">Play Again</button>
+      </div>
+    </div>
+
     <footer>
-        <div>
-            <a href="instructions.html">How to Play</a> |
-            <a href="https://github.com/laydros/hexmeld" target="_blank">View on GitHub</a>
-        </div>
-        <div class="version" id="versionDisplay"></div>
+      <div>
+        <a href="instructions.html">How to Play</a> ·
+        <a href="https://github.com/laydros/hexmeld" target="_blank" rel="noopener">View on GitHub</a>
+      </div>
+      <div id="versionDisplay"></div>
     </footer>
 
-    <script>
+    <script type="module">
+        // Theme toggle: cycles system → dark → light (persists)
+        (()=>{const k='hexmeld-theme',b=document.body,t=document.getElementById('themeToggle');
+        const apply=v=>{b.classList.remove('theme-dark','theme-light');if(v) b.classList.add('theme-'+v);if(t) t.setAttribute('aria-pressed',v?'true':'false');};
+        const stored=localStorage.getItem(k);apply(stored);
+        t&&t.addEventListener('click',()=>{const v=b.classList.contains('theme-dark')?'light':b.classList.contains('theme-light')?null:'dark';apply(v);v?localStorage.setItem(k,v):localStorage.removeItem(k);});})();
+
+        // HUD refs
+        const elScore=document.getElementById('score');
+        const elHigh=document.getElementById('high');
+        const elTurn=document.getElementById('turn');
+        const btnAgain=document.getElementById('playAgain');
+        const cbHint=document.getElementById('cbHint');
+
+        export function hudSet(score, high, turn){
+          if(elScore) elScore.textContent=score|0;
+          if(elHigh) elHigh.textContent=high|0;
+          if(elTurn) elTurn.textContent=turn|0;
+        }
+
+        btnAgain&&btnAgain.addEventListener('click',()=>{ if(typeof restartGame==='function') restartGame(); });
+
+        export function flashInvalid(el){ if(!el) return; el.classList.add('flash-red'); setTimeout(()=>el.classList.remove('flash-red'), 400); }
+
+        // Color-blind mode toggle + persistent state
+        const cbKey='hexmeld-cb', cbBtn=document.getElementById('cbToggle');
+        let cbOn=localStorage.getItem(cbKey)==='1';
+        cbBtn&&cbBtn.setAttribute('aria-pressed', cbOn?'true':'false');
+        const updateCBHint=()=>{ if(cbHint) cbHint.hidden=!cbOn; };
+        updateCBHint();
+        cbBtn&&cbBtn.addEventListener('click',()=>{cbOn=!cbOn; localStorage.setItem(cbKey, cbOn?'1':'0'); cbBtn.setAttribute('aria-pressed', cbOn?'true':'false'); updateCBHint(); if(typeof redrawBoard==='function') redrawBoard();});
+
+        // Helper to overlay hatch + label on a piece at (x,y) with radius r and colorIndex (0..7).
+        export function drawCBOverlay(ctx,x,y,r,colorIndex){
+          if(!cbOn) return;
+          ctx.save();
+          const ang=[0,45,90,135,22,68,115,160][colorIndex%8]*Math.PI/180;
+          ctx.translate(x,y); ctx.rotate(ang); ctx.translate(-x,-y);
+          ctx.globalAlpha=0.25; ctx.strokeStyle='#000'; ctx.lineWidth=1;
+          for(let i=-r;i<=r;i+=4){ ctx.beginPath(); ctx.moveTo(x-r, y+i); ctx.lineTo(x+r, y+i); ctx.stroke(); }
+          ctx.setTransform(1,0,0,1,0,0);
+          ctx.globalAlpha=0.9; ctx.fillStyle='#000'; ctx.font='bold 12px system-ui, sans-serif';
+          const L='ABCDEFGH'; ctx.textAlign='center'; ctx.textBaseline='middle';
+          ctx.fillText(L[colorIndex%8], x, y);
+          ctx.restore();
+        }
+
         // Version check
         const GAME_VERSION = '1.0.8';
         console.log('Hexmeld version:', GAME_VERSION);
@@ -473,7 +347,7 @@
 
             // Load high score
             loadHighScore();
-            document.getElementById('highScoreDisplay').textContent = highScore;
+            hudSet(score, highScore, turnCount);
 
             // Generate initial preview
             preview = generatePreview();
@@ -494,6 +368,10 @@
             updateScore();
             updateTurnDisplay();
             render();
+        }
+
+        export function restartGame(){
+            init();
         }
 
         // Update available colors based on turn count
@@ -546,12 +424,12 @@
 
         // Update score display
         function updateScore() {
-            document.getElementById('score').textContent = score;
+            hudSet(score, highScore, turnCount);
         }
 
         // Update turn display
         function updateTurnDisplay() {
-            document.getElementById('turns').textContent = turnCount;
+            hudSet(score, highScore, turnCount);
         }
 
         // Get all valid hex cells for the board
@@ -683,6 +561,7 @@
             ctx.arc(centerX, centerY, HEX_SIZE * 0.7 * scale, 0, Math.PI * 2);
             ctx.fillStyle = COLORS[colorIndex];
             ctx.fill();
+            drawCBOverlay(ctx, centerX, centerY, HEX_SIZE * 0.7 * scale, colorIndex);
 
             if (isSelected) {
                 ctx.strokeStyle = '#000';
@@ -782,6 +661,10 @@
             }
         }
 
+        function redrawBoard(){
+            render();
+        }
+
         // ====== ANIMATION FUNCTIONS ======
 
         // Animate ball movement from source to destination
@@ -829,6 +712,7 @@
             const [srcQ, srcR] = sourceKey.split(',').map(Number);
             blockedCell = { q: destQ, r: destR, flashProgress: 0 };
             blockedSourceCell = { q: srcQ, r: srcR, flashProgress: 0 };
+            flashInvalid(document.getElementById('gameContainer'));
 
             addAnimation(
                 (progress) => {
@@ -1036,14 +920,14 @@
             if (score > highScore) {
                 highScore = score;
                 saveHighScore();
-                document.getElementById('highScoreDisplay').textContent = highScore;
             }
+            hudSet(score, highScore, turnCount);
 
             // Display scores
             document.getElementById('finalScore').textContent = score;
             document.getElementById('finalTurns').textContent = turnCount;
             document.getElementById('highScore').textContent = highScore;
-            document.getElementById('gameOver').style.display = 'block';
+            document.getElementById('gameOver').style.display = 'flex';
         }
 
         // Spawn new balls with animation
@@ -1203,7 +1087,7 @@
 
         // Handle reset button
         document.getElementById('resetButton').addEventListener('click', () => {
-            init();
+            restartGame();
         });
 
         // Start game

--- a/instructions.html
+++ b/instructions.html
@@ -4,141 +4,40 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hexmeld - How to Play</title>
+    <link rel="icon" href="assets/hexmeld-icon.svg" type="image/svg+xml">
+    <link rel="mask-icon" href="assets/hexmeld-icon.svg" color="#5b7fff">
+    <meta name="theme-color" content="#0b1020">
+    <link rel="manifest" href="assets/manifest.webmanifest">
     <style>
-        * {
-            box-sizing: border-box;
-        }
-
-        body {
-            margin: 0;
-            padding: 0;
-            font-family: Arial, sans-serif;
-            background-color: #f0f0f0;
-            display: flex;
-            flex-direction: column;
-            min-height: 100vh;
-        }
-
-        header {
-            width: 100%;
-            background-color: #333;
-            color: white;
-            padding: 20px 0;
-            text-align: center;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-        }
-
-        header h1 {
-            margin: 0;
-            font-size: 32px;
-            font-weight: bold;
-        }
-
-        main {
-            flex: 1;
-            max-width: 800px;
-            width: 100%;
-            margin: 0 auto;
-            padding: 30px 20px;
-            background-color: white;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-        }
-
-        h2 {
-            color: #333;
-            border-bottom: 2px solid #4CAF50;
-            padding-bottom: 10px;
-            margin-top: 30px;
-        }
-
-        h3 {
-            color: #555;
-            margin-top: 20px;
-        }
-
-        p, li {
-            line-height: 1.6;
-            color: #444;
-        }
-
-        ul {
-            margin-left: 20px;
-        }
-
-        .color-demo {
-            display: inline-block;
-            width: 15px;
-            height: 15px;
-            border-radius: 50%;
-            border: 1px solid #333;
-            margin-right: 5px;
-            vertical-align: middle;
-        }
-
-        .back-button {
-            display: inline-block;
-            margin-top: 30px;
-            padding: 12px 30px;
-            background-color: #4CAF50;
-            color: white;
-            text-decoration: none;
-            border-radius: 5px;
-            font-weight: bold;
-        }
-
-        .back-button:hover {
-            background-color: #45a049;
-        }
-
-        footer {
-            width: 100%;
-            background-color: #333;
-            color: white;
-            padding: 15px 0;
-            text-align: center;
-            font-size: 14px;
-        }
-
-        footer a {
-            color: #4CAF50;
-            text-decoration: none;
-            margin: 0 10px;
-        }
-
-        footer a:hover {
-            text-decoration: underline;
-        }
-
-        @media (max-width: 600px) {
-            header h1 {
-                font-size: 24px;
-            }
-
-            header {
-                padding: 15px 0;
-            }
-
-            main {
-                padding: 20px 15px;
-            }
-
-            h2 {
-                font-size: 20px;
-            }
-
-            footer {
-                font-size: 12px;
-                padding: 10px 0;
-            }
-        }
+        :root{--bg:#0b1020;--panel:#11182a;--text:#e8ebf0;--muted:#93a0b4;--primary:#5b7fff;--gap:18px}
+        html{color-scheme:dark light}
+        @media (prefers-color-scheme: light){:root{--bg:#f6f7fb;--panel:#fff;--text:#0f1422;--muted:#5b667a}}
+        *,*::before,*::after{box-sizing:border-box}
+        body{margin:0;min-height:100vh;display:flex;justify-content:center;align-items:flex-start;padding:var(--gap);background:var(--bg);color:var(--text);font:15px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Arial}
+        body.theme-dark{color-scheme:dark}
+        body.theme-light{color-scheme:light}
+        .panel{max-width:920px;width:100%;background:var(--panel);padding:28px;border-radius:12px;box-shadow:0 12px 28px rgba(0,0,0,.25)}
+        h1{margin:0 0 12px;font-size:2rem}
+        h2{margin:2rem 0 1rem;font-size:1.35rem}
+        h3{margin:1.5rem 0 .75rem;font-size:1.1rem;color:var(--muted)}
+        p,li{color:var(--text)}
+        ul{padding-left:1.25rem}
+        a{color:var(--primary)}
+        .button{display:inline-block;padding:.5rem .75rem;border-radius:8px;border:0;font-weight:600;color:#fff;background:var(--primary);text-decoration:none;cursor:pointer}
+        .button:hover{filter:brightness(1.08)}
+        .button:active{filter:brightness(.95)}
+        .color-demo{display:inline-block;width:16px;height:16px;border-radius:50%;border:2px solid rgba(0,0,0,.4);margin-right:6px;vertical-align:middle}
+        footer{margin-top:2rem;font-size:.85rem;color:var(--muted)}
+        footer a{color:inherit;text-decoration:none}
+        footer a:hover{text-decoration:underline}
+        @media (max-width:768px){body{padding:16px}}
     </style>
 </head>
 <body>
-    <header>
+    <main class="panel">
         <h1>Hexmeld - How to Play</h1>
-    </header>
+        <p><a href="index.html" class="button">Play Game</a></p>
 
-    <main>
         <h2>Objective</h2>
         <p>Create groups of 6 or more balls of the same color by moving balls across the hexagonal board. The larger the group, the more points you score!</p>
 
@@ -146,27 +45,27 @@
 
         <h3>Moving Balls</h3>
         <ul>
-            <li><strong>Select:</strong> Click on any ball to select it (it will get a black outline)</li>
-            <li><strong>Move:</strong> Click on an empty hex to move the selected ball there</li>
-            <li><strong>Path:</strong> Balls can only move to cells they can reach via empty hexes (no jumping over other balls)</li>
-            <li><strong>Blocked:</strong> If you try to move to an unreachable location, both the source ball and destination hex will flash red</li>
+            <li><strong>Select:</strong> Click on any ball to select it (it will get a black outline).</li>
+            <li><strong>Move:</strong> Click on an empty hex to move the selected ball there.</li>
+            <li><strong>Path:</strong> Balls can only move to cells they can reach via empty hexes (no jumping over other balls).</li>
+            <li><strong>Blocked:</strong> If you try to move to an unreachable location, both the source ball and destination hex will flash red.</li>
         </ul>
 
         <h3>Scoring</h3>
         <ul>
-            <li>Connect <strong>6 or more</strong> balls of the same color to score points</li>
-            <li>Groups must be adjacent (touching each other on hex edges)</li>
-            <li>When a group forms, the balls disappear and you earn points</li>
+            <li>Connect <strong>6 or more</strong> balls of the same color to score points.</li>
+            <li>Groups must be adjacent (touching each other on hex edges).</li>
+            <li>When a group forms, the balls disappear and you earn points.</li>
             <li>Points formula: <strong>6 balls = 6 points</strong>, <strong>7 balls = 8 points</strong>, <strong>8 balls = 11 points</strong>, etc.</li>
             <li>The score increases faster with larger groups!</li>
         </ul>
 
         <h3>New Ball Spawning</h3>
         <ul>
-            <li>After each move (if no group formed), 3 new balls spawn in random empty locations</li>
-            <li>The <strong>"Next:"</strong> preview shows which colors will spawn next</li>
-            <li><strong>After turn 40:</strong> 4 balls spawn instead of 3 (difficulty increases!)</li>
-            <li>If spawned balls form a group, they are removed immediately</li>
+            <li>After each move (if no group formed), 3 new balls spawn in random empty locations.</li>
+            <li>The <strong>"Next:"</strong> preview shows which colors will spawn next.</li>
+            <li><strong>After turn 40:</strong> 4 balls spawn instead of 3 (difficulty increases!).</li>
+            <li>If spawned balls form a group, they are removed immediately.</li>
         </ul>
 
         <h3>Colors</h3>
@@ -190,19 +89,16 @@
 
         <h2>Strategy Tips</h2>
         <ul>
-            <li>Plan ahead - look at the "Next" preview to see what colors are coming</li>
-            <li>Try to build groups near each other so you can merge them</li>
-            <li>Don't let one color dominate the board - clear groups regularly</li>
+            <li>Plan ahead - look at the "Next" preview to see what colors are coming.</li>
+            <li>Try to build groups near each other so you can merge them.</li>
+            <li>Don't let one color dominate the board - clear groups regularly.</li>
             <li>Larger groups give exponentially more points - aim for big combos!</li>
-            <li>Keep pathways open so balls can reach where they need to go</li>
+            <li>Keep pathways open so balls can reach where they need to go.</li>
         </ul>
 
-        <a href="index.html" class="back-button">← Back to Game</a>
+        <footer>
+            <a href="https://github.com/laydros/hexmeld" target="_blank" rel="noopener">View on GitHub</a>
+        </footer>
     </main>
-
-    <footer>
-        <a href="index.html">Play Game</a> |
-        <a href="https://github.com/laydros/hexmeld" target="_blank">View on GitHub</a>
-    </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh the game layout with a compact HUD that exposes score, turn controls, theme switching, and a color-blind overlay toggle
- wire the canvas logic to new HUD helpers for score updates, restart, invalid move feedback, and the hatch/label overlay
- add a refreshed SVG icon, manifest metadata, and restyled instructions page to match the new palette

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68dda720548c8329af23af98b255ea2d