### PR TITLE
Restore previous layout width and remove color blind mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,14 +9,13 @@
     <meta name="theme-color" content="#0b1020">
     <link rel="manifest" href="assets/manifest.webmanifest">
     <style>
-        :root{--bg:#0b1020;--panel:#11182a;--text:#e8ebf0;--muted:#93a0b4;--primary:#5b7fff;--danger:#ff6b6b;--gap:12px}
-        html{color-scheme:dark light}
-        @media (prefers-color-scheme: light){:root{--bg:#f6f7fb;--panel:#fff;--text:#0f1422;--muted:#5b667a}}
+        :root{color-scheme:dark light;--bg-dark:#0b1020;--panel-dark:#11182a;--text-dark:#e8ebf0;--muted-dark:#93a0b4;--bg-light:#f6f7fb;--panel-light:#fff;--text-light:#0f1422;--muted-light:#5b667a;--primary:#5b7fff;--danger:#ff6b6b;--gap:12px}
         *,*::before,*::after{box-sizing:border-box}
-        body{margin:0;min-height:100vh;display:flex;flex-direction:column;gap:var(--gap);padding:var(--gap);background:var(--bg);color:var(--text);font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Arial}
-        body.theme-dark{color-scheme:dark}
-        body.theme-light{color-scheme:light}
-        .panel{max-width:920px;width:100%;margin:0 auto;padding:12px;background:var(--panel);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.2)}
+        body{margin:0;min-height:100vh;display:flex;flex-direction:column;gap:var(--gap);padding:var(--gap);font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Arial;--bg:var(--bg-dark);--panel:var(--panel-dark);--text:var(--text-dark);--muted:var(--muted-dark);background:var(--bg);color:var(--text)}
+        body.theme-dark{color-scheme:dark;--bg:var(--bg-dark);--panel:var(--panel-dark);--text:var(--text-dark);--muted:var(--muted-dark)}
+        body.theme-light{color-scheme:light;--bg:var(--bg-light);--panel:var(--panel-light);--text:var(--text-light);--muted:var(--muted-light)}
+        @media (prefers-color-scheme: light){body:not(.theme-dark){color-scheme:light;--bg:var(--bg-light);--panel:var(--panel-light);--text:var(--text-light);--muted:var(--muted-light)}}
+        .panel{max-width:760px;width:100%;margin:0 auto;padding:12px;background:var(--panel);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.2)}
         .header{display:flex;justify-content:space-between;align-items:baseline;gap:var(--gap)}
         h1{font-size:1.4rem;margin:0}
         .meta{color:var(--muted)}
@@ -30,7 +29,7 @@
         @keyframes flash{50%{filter:brightness(1.8) saturate(1.4)}}
         main{flex:1;display:flex;flex-direction:column;align-items:center;gap:var(--gap);width:100%}
         #gameContainer{display:flex;flex-direction:column;gap:var(--gap);align-items:center}
-        #canvas{width:100%;height:auto;max-width:820px;border-radius:12px;background:#0001;border:1px solid #0004;box-shadow:0 12px 24px rgba(0,0,0,.25)}
+        #canvas{width:100%;height:auto;max-width:640px;border-radius:12px;background:#0001;border:1px solid #0004;box-shadow:0 12px 24px rgba(0,0,0,.25)}
         #preview{display:flex;gap:8px;align-items:center;font-weight:600}
         .previewBall{width:22px;height:22px;border-radius:50%;border:2px solid rgba(0,0,0,.35)}
         footer{margin-top:auto;text-align:center;font-size:.85rem;color:var(--muted)}
@@ -42,7 +41,6 @@
         #gameOver h2{margin:0 0 12px;font-size:1.5rem}
         #gameOver p{margin:6px 0;color:var(--muted)}
         #resetButton{margin-top:16px}
-        .cb-hint{font-size:.9em;color:var(--muted)}
         @media (max-width:768px){
             body{padding:var(--gap) 0 calc(var(--gap)*2);}
             .panel{border-radius:0;}
@@ -60,7 +58,6 @@
       </div>
       <div style="display:flex;gap:8px;align-items:center">
         <button id="themeToggle" class="button ghost" aria-pressed="false" title="Toggle theme">Theme</button>
-        <button id="cbToggle" class="button ghost" aria-pressed="false" title="Color-blind mode">CB</button>
         <button id="playAgain" class="button" title="Restart">Play Again</button>
       </div>
     </header>
@@ -71,7 +68,6 @@
           <span>Next:</span>
         </div>
         <canvas id="canvas"></canvas>
-        <div class="cb-hint" id="cbHint" hidden>Color-blind overlay active.</div>
       </section>
     </main>
 
@@ -104,7 +100,6 @@
         const elHigh=document.getElementById('high');
         const elTurn=document.getElementById('turn');
         const btnAgain=document.getElementById('playAgain');
-        const cbHint=document.getElementById('cbHint');
 
         export function hudSet(score, high, turn){
           if(elScore) elScore.textContent=score|0;
@@ -115,29 +110,6 @@
         btnAgain&&btnAgain.addEventListener('click',()=>{ if(typeof restartGame==='function') restartGame(); });
 
         export function flashInvalid(el){ if(!el) return; el.classList.add('flash-red'); setTimeout(()=>el.classList.remove('flash-red'), 400); }
-
-        // Color-blind mode toggle + persistent state
-        const cbKey='hexmeld-cb', cbBtn=document.getElementById('cbToggle');
-        let cbOn=localStorage.getItem(cbKey)==='1';
-        cbBtn&&cbBtn.setAttribute('aria-pressed', cbOn?'true':'false');
-        const updateCBHint=()=>{ if(cbHint) cbHint.hidden=!cbOn; };
-        updateCBHint();
-        cbBtn&&cbBtn.addEventListener('click',()=>{cbOn=!cbOn; localStorage.setItem(cbKey, cbOn?'1':'0'); cbBtn.setAttribute('aria-pressed', cbOn?'true':'false'); updateCBHint(); if(typeof redrawBoard==='function') redrawBoard();});
-
-        // Helper to overlay hatch + label on a piece at (x,y) with radius r and colorIndex (0..7).
-        export function drawCBOverlay(ctx,x,y,r,colorIndex){
-          if(!cbOn) return;
-          ctx.save();
-          const ang=[0,45,90,135,22,68,115,160][colorIndex%8]*Math.PI/180;
-          ctx.translate(x,y); ctx.rotate(ang); ctx.translate(-x,-y);
-          ctx.globalAlpha=0.25; ctx.strokeStyle='#000'; ctx.lineWidth=1;
-          for(let i=-r;i<=r;i+=4){ ctx.beginPath(); ctx.moveTo(x-r, y+i); ctx.lineTo(x+r, y+i); ctx.stroke(); }
-          ctx.setTransform(1,0,0,1,0,0);
-          ctx.globalAlpha=0.9; ctx.fillStyle='#000'; ctx.font='bold 12px system-ui, sans-serif';
-          const L='ABCDEFGH'; ctx.textAlign='center'; ctx.textBaseline='middle';
-          ctx.fillText(L[colorIndex%8], x, y);
-          ctx.restore();
-        }
 
         // Version check
         const GAME_VERSION = '1.0.8';
@@ -565,7 +537,6 @@
             ctx.arc(centerX, centerY, HEX_SIZE * 0.7 * scale, 0, Math.PI * 2);
             ctx.fillStyle = COLORS[colorIndex];
             ctx.fill();
-            drawCBOverlay(ctx, centerX, centerY, HEX_SIZE * 0.7 * scale, colorIndex);
 
             if (isSelected) {
                 ctx.strokeStyle = '#000';

--- a/instructions.html
+++ b/instructions.html
@@ -9,14 +9,13 @@
     <meta name="theme-color" content="#0b1020">
     <link rel="manifest" href="assets/manifest.webmanifest">
     <style>
-        :root{--bg:#0b1020;--panel:#11182a;--text:#e8ebf0;--muted:#93a0b4;--primary:#5b7fff;--gap:18px}
-        html{color-scheme:dark light}
-        @media (prefers-color-scheme: light){:root{--bg:#f6f7fb;--panel:#fff;--text:#0f1422;--muted:#5b667a}}
+        :root{color-scheme:dark light;--bg-dark:#0b1020;--panel-dark:#11182a;--text-dark:#e8ebf0;--muted-dark:#93a0b4;--bg-light:#f6f7fb;--panel-light:#fff;--text-light:#0f1422;--muted-light:#5b667a;--primary:#5b7fff;--gap:18px}
         *,*::before,*::after{box-sizing:border-box}
-        body{margin:0;min-height:100vh;display:flex;justify-content:center;align-items:flex-start;padding:var(--gap);background:var(--bg);color:var(--text);font:15px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Arial}
-        body.theme-dark{color-scheme:dark}
-        body.theme-light{color-scheme:light}
-        .panel{max-width:920px;width:100%;background:var(--panel);padding:28px;border-radius:12px;box-shadow:0 12px 28px rgba(0,0,0,.25)}
+        body{margin:0;min-height:100vh;display:flex;justify-content:center;align-items:flex-start;padding:var(--gap);font:15px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Arial;--bg:var(--bg-dark);--panel:var(--panel-dark);--text:var(--text-dark);--muted:var(--muted-dark);background:var(--bg);color:var(--text)}
+        body.theme-dark{color-scheme:dark;--bg:var(--bg-dark);--panel:var(--panel-dark);--text:var(--text-dark);--muted:var(--muted-dark)}
+        body.theme-light{color-scheme:light;--bg:var(--bg-light);--panel:var(--panel-light);--text:var(--text-light);--muted:var(--muted-light)}
+        @media (prefers-color-scheme: light){body:not(.theme-dark){color-scheme:light;--bg:var(--bg-light);--panel:var(--panel-light);--text:var(--text-light);--muted:var(--muted-light)}}
+        .panel{max-width:760px;width:100%;background:var(--panel);padding:28px;border-radius:12px;box-shadow:0 12px 28px rgba(0,0,0,.25)}
         h1{margin:0 0 12px;font-size:2rem}
         h2{margin:2rem 0 1rem;font-size:1.35rem}
         h3{margin:1.5rem 0 .75rem;font-size:1.1rem;color:var(--muted)}
@@ -103,5 +102,8 @@
             <a href="https://github.com/laydros/hexmeld" target="_blank" rel="noopener">View on GitHub</a>
         </footer>
     </main>
+    <script>
+        (()=>{const v=localStorage.getItem('hexmeld-theme');if(v){document.body.classList.add('theme-'+v);}})();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- shrink the game and instructions panels to their previous desktop widths
- fix the theme toggle by wiring CSS variables to the stored theme classes
- remove the color blind mode controls and overlay until they are ready again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb0c6645c83298075a8aa0572788c