### PR TITLE
Add service worker to cache core assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,9 +153,15 @@
         }
 
         // Version check
-        const GAME_VERSION = '1.3.0';
+        const GAME_VERSION = '1.4.0';
         console.log('Hexmeld version:', GAME_VERSION);
         document.getElementById('versionDisplay').textContent = `v${GAME_VERSION}`;
+
+        if ('serviceWorker' in navigator) {
+          navigator.serviceWorker.register('service-worker.js').catch((error) => {
+            console.error('Hexmeld service worker registration failed:', error);
+          });
+        }
 
         const STORAGE_KEY = 'hexmeldGameState';
         let saveGameTimeout = null;

--- a/instructions.html
+++ b/instructions.html
@@ -103,8 +103,14 @@
             <a href="https://github.com/laydros/hexmeld" target="_blank" rel="noopener">View on GitHub</a>
         </footer>
     </main>
-    <script>
+    <script type="module">
         (()=>{const v=localStorage.getItem('hexmeld-theme');if(v){document.body.classList.add('theme-'+v);}})();
+
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('service-worker.js').catch((error) => {
+                console.error('Hexmeld service worker registration failed:', error);
+            });
+        }
     </script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,56 @@
+const CACHE_VERSION = 'v2';
+const CACHE_NAME = `hexmeld-cache-${CACHE_VERSION}`;
+const PRECACHE_URLS = [
+  './',
+  './index.html',
+  './instructions.html',
+  './assets/manifest.webmanifest',
+  './assets/hexmeld-icon.svg',
+  './assets/hexmeld-icon-180.png',
+  './assets/hexmeld-icon-192.png',
+  './assets/hexmeld-icon-512.png'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames
+          .filter((name) => name.startsWith('hexmeld-cache-') && name !== CACHE_NAME)
+          .map((name) => caches.delete(name))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type === 'opaque') {
+            return response;
+          }
+
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+          return response;
+        })
+        .catch(() => caches.match('./index.html'));
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add a root service worker that precaches the HTML shell, manifest, and icon assets and cleans up old caches
- register the shared service worker from the main game and instructions pages while bumping the displayed game version for the release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea64014ec83299eade83d34dbea00