### PR TITLE
Refactor HUD synchronization helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
         }
 
         // Version check
-        const GAME_VERSION = '1.8.1';
+        const GAME_VERSION = '1.8.2';
         console.log('Hexmeld version:', GAME_VERSION);
         document.getElementById('versionDisplay').textContent = `v${GAME_VERSION}`;
 
@@ -860,8 +860,7 @@
                 }
             }
 
-            updateScore();
-            updateTurnDisplay();
+            syncHud();
             render();
             queueSaveGameState();
         }
@@ -961,14 +960,8 @@
             queueSaveGameState();
         }
 
-        // Update score display
-        function updateScore() {
-            hudSet(score, highScore, turnCount, grid.size);
-            queueSaveGameState();
-        }
-
-        // Update turn display
-        function updateTurnDisplay() {
+        // Synchronize HUD with current game state
+        function syncHud() {
             hudSet(score, highScore, turnCount, grid.size);
             queueSaveGameState();
         }
@@ -1763,7 +1756,7 @@
                 checkAndRemoveGroups(spawnedCells, (scoreGained) => {
                     if (scoreGained > 0) {
                         score += scoreGained;
-                        updateScore();
+                        syncHud();
                     }
 
                     // Generate new preview
@@ -1832,12 +1825,12 @@
                                 // Group formed - add score with combo multiplier, don't spawn
                                 const finalScore = Math.floor(scoreGained * comboMultiplier);
                                 score += finalScore;
-                                updateScore();
+                                syncHud();
                                 render();
                             } else {
                                 // No group - increment turn, reset combo, spawn new balls
                                 turnCount++;
-                                updateTurnDisplay();
+                                syncHud();
                                 updateAvailableColors();
                                 comboCount = 0;
                                 spawnBalls();


### PR DESCRIPTION
## Summary
- replace the duplicate HUD update functions with a single syncHud helper
- update score and turn update call sites to use the shared HUD synchronizer
- bump the GAME_VERSION to 1.8.2 to reflect the change

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df472567cc8329b342f5162037e17f