### PR TITLE
Make random events deterministic across undo

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
         }
 
         // Version check
-        const GAME_VERSION = '1.8.4';
+        const GAME_VERSION = '1.8.5';
         console.log('Hexmeld version:', GAME_VERSION);
         document.getElementById('versionDisplay').textContent = `v${GAME_VERSION}`;
 
@@ -357,6 +357,74 @@
 
         const SPAWN_INCREASES_SORTED = [...(SPAWN_CONFIG.increases || [])].sort((a, b) => a.afterTurn - b.afterTurn);
         const SPAWN_THRESHOLDS_SORTED = [...(SPAWN_CONFIG.boardThresholds || [])].sort((a, b) => a.emptyCells - b.emptyCells);
+        const RNG_STATE_KEY = 'hexmeldRngState';
+
+        function generateSeed() {
+            if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+                const buffer = new Uint32Array(1);
+                crypto.getRandomValues(buffer);
+                return buffer[0] >>> 0;
+            }
+
+            const now = Date.now() >>> 0;
+            let entropy = now;
+            if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+                entropy ^= Math.floor(performance.now() * 1000) >>> 0;
+            }
+
+            entropy ^= entropy << 13;
+            entropy ^= entropy >>> 17;
+            entropy ^= entropy << 5;
+            return entropy >>> 0;
+        }
+
+        function createDeterministicRng(seedValue) {
+            let state = (Number.isFinite(seedValue) ? seedValue : 0) >>> 0;
+            return {
+                next() {
+                    state = (state + 0x6D2B79F5) >>> 0;
+                    let t = state;
+                    t = Math.imul(t ^ (t >>> 15), t | 1);
+                    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+                    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+                },
+                getState() {
+                    return state >>> 0;
+                },
+                setState(value) {
+                    if (!Number.isFinite(value)) return;
+                    state = value >>> 0;
+                }
+            };
+        }
+
+        let rng = createDeterministicRng(generateSeed());
+
+        function getRngState() {
+            return rng.getState();
+        }
+
+        function setRngState(newState) {
+            if (!Number.isFinite(newState)) return;
+            rng.setState(newState);
+        }
+
+        function reseedRng() {
+            rng.setState(generateSeed());
+        }
+
+        function rngNext() {
+            return rng.next();
+        }
+
+        function rngNextInt(maxExclusive) {
+            if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) {
+                return 0;
+            }
+            const value = rngNext() * maxExclusive;
+            return Math.min(Math.floor(value), maxExclusive - 1);
+        }
+
         // ==================================================
 
         // Canvas setup
@@ -399,7 +467,8 @@
                     gameOver,
                     highScore,
                     comboCount: storedCombo,
-                    history: serializeSnapshot(lastTurnSnapshot)
+                    history: serializeSnapshot(lastTurnSnapshot),
+                    [RNG_STATE_KEY]: getRngState()
                 };
                 localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
             } catch (err) {
@@ -512,7 +581,8 @@
                 preview: clonePreviewArray(preview),
                 availableColorCount,
                 gameOver,
-                comboCount
+                comboCount,
+                rngState: getRngState()
             };
         }
 
@@ -528,7 +598,8 @@
                     ? Math.min(Math.max(Math.floor(snapshot.availableColorCount), 1), COLORS.length)
                     : COLOR_CONFIG.startingColors,
                 gameOver: !!snapshot.gameOver,
-                comboCount: Number.isFinite(snapshot.comboCount) ? Math.max(0, Math.floor(snapshot.comboCount)) : 0
+                comboCount: Number.isFinite(snapshot.comboCount) ? Math.max(0, Math.floor(snapshot.comboCount)) : 0,
+                rngState: Number.isFinite(snapshot.rngState) ? snapshot.rngState >>> 0 : getRngState()
             };
         }
 
@@ -552,7 +623,8 @@
                     ? Math.min(Math.max(Math.floor(entry.availableColorCount), 1), COLORS.length)
                     : COLOR_CONFIG.startingColors,
                 gameOver: !!entry.gameOver,
-                comboCount: Number.isFinite(entry.comboCount) ? Math.max(0, Math.floor(entry.comboCount)) : 0
+                comboCount: Number.isFinite(entry.comboCount) ? Math.max(0, Math.floor(entry.comboCount)) : 0,
+                rngState: Number.isFinite(entry.rngState) ? entry.rngState >>> 0 : getRngState()
             };
         }
 
@@ -771,8 +843,6 @@
             const snapshot = lastTurnSnapshot;
             lastTurnSnapshot = null;
 
-            const preservedPreview = clonePreviewArray(preview);
-
             grid = cloneGridState(snapshot.grid);
             score = Number.isFinite(snapshot.score) ? Math.max(0, Math.floor(snapshot.score)) : 0;
             turnCount = Number.isFinite(snapshot.turnCount) ? Math.max(0, Math.floor(snapshot.turnCount)) : 0;
@@ -781,8 +851,12 @@
                 ? Math.min(Math.max(Math.floor(snapshot.availableColorCount), 1), COLORS.length)
                 : COLOR_CONFIG.startingColors;
             const snapshotPreview = Array.isArray(snapshot.preview) ? clonePreviewArray(snapshot.preview) : [];
-            preview = preservedPreview.length > 0 ? preservedPreview : snapshotPreview;
+            preview = snapshotPreview;
             gameOver = !!snapshot.gameOver;
+
+            if (Number.isFinite(snapshot.rngState)) {
+                setRngState(snapshot.rngState);
+            }
 
             hudSet(score, highScore, turnCount, grid.size);
             updatePreviewDisplay();
@@ -839,6 +913,13 @@
             if (!data || data.version !== GAME_VERSION) {
                 clearSavedGameState();
                 return false;
+            }
+
+            const storedRngState = data && Number.isFinite(data[RNG_STATE_KEY]) ? data[RNG_STATE_KEY] >>> 0 : null;
+            if (Number.isFinite(storedRngState)) {
+                setRngState(storedRngState);
+            } else {
+                reseedRng();
             }
 
             grid.clear();
@@ -924,6 +1005,8 @@
                 clearSavedGameState();
             }
 
+            reseedRng();
+
             grid.clear();
             score = 0;
             turnCount = 0;
@@ -940,9 +1023,9 @@
             const emptyCells = getAllEmptyCells();
             for (let i = 0; i < startBalls; i++) {
                 if (emptyCells.length > 0) {
-                    const idx = Math.floor(Math.random() * emptyCells.length);
+                    const idx = rngNextInt(emptyCells.length);
                     const cell = emptyCells.splice(idx, 1)[0];
-                    const color = Math.floor(Math.random() * availableColorCount);
+                    const color = rngNextInt(availableColorCount);
                     grid.set(cell, { color });
                 }
             }
@@ -1011,7 +1094,7 @@
             const spawnTotal = Math.min(nextTurnSpawnCount, emptyCellsCount);
             const previewArray = [];
             for (let i = 0; i < spawnTotal; i++) {
-                previewArray.push(Math.floor(Math.random() * availableColorCount));
+                previewArray.push(rngNextInt(availableColorCount));
             }
             return previewArray;
         }
@@ -1811,7 +1894,7 @@
             } else if (preview.length < spawnCount) {
                 const needed = spawnCount - preview.length;
                 for (let i = 0; i < needed; i++) {
-                    preview.push(Math.floor(Math.random() * availableColorCount));
+                    preview.push(rngNextInt(availableColorCount));
                 }
                 updatePreviewDisplay();
             }
@@ -1830,7 +1913,7 @@
             for (let i = 0; i < ballsToSpawn; i++) {
                 if (emptyCells.length === 0) break;
 
-                const idx = Math.floor(Math.random() * emptyCells.length);
+                const idx = rngNextInt(emptyCells.length);
                 const cellKey = emptyCells.splice(idx, 1)[0];
                 cellsAndColors.push({ cellKey, color: preview[i] });
             }


### PR DESCRIPTION
## Summary
- add a deterministic PRNG based on Mulberry32 and helper utilities
- persist and restore RNG state with undo snapshots and saved games so random events replay identically
- reseed the RNG for new games and update the version display

## Testing
- not run (not run in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfc84b5d3c8329a31b210166eafeb0